### PR TITLE
without this cli usage will often ask for too many tokens and die...

### DIFF
--- a/lib/toodledo/session.rb
+++ b/lib/toodledo/session.rb
@@ -111,7 +111,7 @@ module Toodledo
       logger.debug("disconnect()") if logger
       
       token_path = get_token_file(user_id)
-      if token_path
+      if token_path and expired?
         logger.debug("deleting token path()") if logger        
         File.delete(token_path)
       end


### PR DESCRIPTION
do not nuke the token on disconnect _unless_ it is too old.  avoids requesting too many tokens.
