### PR TITLE
added 'today', 'tomorrow', and 'overdue' commands

### DIFF
--- a/lib/toodledo/command_line/list_overdue_command.rb
+++ b/lib/toodledo/command_line/list_overdue_command.rb
@@ -1,0 +1,27 @@
+
+module Toodledo  
+  module CommandLine
+    
+    #
+    # Lists the tasks.
+    #
+    class ListOverdueCommand < BaseCommand
+      def initialize(client)
+        super(client, 'overdue', false)
+        self.short_desc = "Overdue tasks"
+        self.description = "Lists overdue tasks in Toodledo."
+      end
+      
+      def execute(args)
+	line = args.join(' ')        
+        Toodledo.begin(client.logger) do |session|            
+          return client.list_overdue_tasks(session, line)
+        end
+        
+        return 0
+      end
+    end
+    
+    
+  end
+end

--- a/lib/toodledo/command_line/list_today_command.rb
+++ b/lib/toodledo/command_line/list_today_command.rb
@@ -1,0 +1,27 @@
+
+module Toodledo  
+  module CommandLine
+    
+    #
+    # Lists the tasks.
+    #
+    class ListTodayCommand < BaseCommand
+      def initialize(client)
+        super(client, 'today', false)
+        self.short_desc = "Today's tasks"
+        self.description = "Lists tasks for today in Toodledo."
+      end
+      
+      def execute(args)
+	line = args.join(' ')        
+        Toodledo.begin(client.logger) do |session|            
+          return client.list_today_tasks(session, line)
+        end
+        
+        return 0
+      end
+    end
+    
+    
+  end
+end

--- a/lib/toodledo/command_line/list_tomorrow_command.rb
+++ b/lib/toodledo/command_line/list_tomorrow_command.rb
@@ -1,0 +1,28 @@
+
+module Toodledo  
+  module CommandLine
+    
+    #
+    # Lists the tasks.
+    #
+    class ListTomorrowCommand < BaseCommand
+      def initialize(client)
+        super(client, 'tomorrow', false)
+        self.short_desc = "Tomorrow's tasks"
+        self.description = "Lists tasks for tomorrow in Toodledo."
+      end
+      
+      def execute(args)
+	line = args.join(' ')        
+ 
+        Toodledo.begin(client.logger) do |session|            
+          return client.list_tomorrow_tasks(session, line)
+        end
+        
+        return 0
+      end
+    end
+    
+    
+  end
+end


### PR DESCRIPTION
Hello,

I implemented three commands that show tasks with the due date of today, tomorrow or in the past (overdue). I use these categories all the time in my iOS PIM (Pocket Informant) and wanted to have them in CLI too. Hope you will find this useful.

This is literally my first attempt to write anything in Ruby, so please let me know if I need to change anything re: formatting, style or coding guidelines.

Thank you for toodledoo CLI!

--Artem
