### PR TITLE
Set file permissions on user config to keep it private.

### DIFF
--- a/lib/toodledo/command_line/client.rb
+++ b/lib/toodledo/command_line/client.rb
@@ -113,7 +113,9 @@ module Toodledo
         FileUtils::mkdir_p TOODLEDO_D, :mode => 0700 unless test ?d, TOODLEDO_D
         test ?e, CONFIG_F and FileUtils::mv CONFIG_F, "#{CONFIG_F}.bak"
         config = CONFIG[/\A.*(?=^\# AUTOCONFIG)/m]
+        save_umask = File.umask(0077)
         open(CONFIG_F, "w") { |f| f.write config }
+        File.umask(save_umask)
     
         edit = (ENV["EDITOR"] || ENV["EDIT"] || "vi") + " '#{CONFIG_F}'"
         system edit or puts "edit '#{CONFIG_F}'"


### PR DESCRIPTION
Changed the umask so that the new file with have 0600 permission (no r/w by group or world).
Changed the umask *back* after we're done creating the file, even though the script is ~done at this point.

(Same patch that I attached to my email, but this was a good excuse to use github for "real" for the first time;)